### PR TITLE
fix map name in storageExit

### DIFF
--- a/storage.json
+++ b/storage.json
@@ -72,7 +72,7 @@
                 {
                  "name":"exitUrl",
                  "type":"string",
-                 "value":"reaktor23.json#storageEntry"
+                 "value":"main.json#storageEntry"
                 }],
          "type":"tilelayer",
          "visible":true,


### PR DESCRIPTION
After renaming `reaktor23.json` to `main.json` the name of the map to jump to from the storage map had to be changed as well 